### PR TITLE
fix: remove dependency to address unrecognised job

### DIFF
--- a/{{ cookiecutter.project_name_dashed }}/.github/workflows/pr_validation.yaml
+++ b/{{ cookiecutter.project_name_dashed }}/.github/workflows/pr_validation.yaml
@@ -10,7 +10,6 @@ jobs:
   detect-unresolved-conflicts:
     name: Detect unresolved merge conflicts
     runs-on: ubuntu-latest
-    needs: semantic_pr
     steps:
       - uses: actions/checkout@v3
       - name: List files with merge conflict markers


### PR DESCRIPTION
#### Description

`pr_evaluation` workflow had one job that depended on another, but the otherjob was below the first one and GA didn't recognise it.

Remove the dependecy, note the job should be listed in topological order for GA, I wrongly assumed they are independent.

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

- Fixes #18 

#### Checklist

<!-- Please go through the following checklist to ensure that your change is
ready for review. Please do not forget to double check the list after you have
modified your PR, e.g., if you have added commits to address reviewer
comments or to fix failing automated checks. **Please check items also if they
do not apply to your change**, e.g., if your change does not require an update
of the user-facing documentation, still check the box.

Generally, **PRs are only reviewed when all boxes are ticked off and all
automated checks pass** (use the comment section below if you believe that
your PR is ready to be merged even though not all boxes were ticked off). -->

- [x] My code follows the [contributing guidelines][contributing-guidelines] of this
    project, including, in particular, with regard to any style guidelines
- [x] The title of my PR complies with the [Conventional Commits
    specification][conv-commits]; in particular, it clearly indicates
    that a change is a breaking change
- [x] I acknowledge that all my commits will be squashed into a single commit,
    using the PR title as the commit message
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have updated the user-facing documentation to describe any new or
    changed behavior
- [x] I have added type annotations for all function/class/method interfaces
    or updated existing ones (only for Python, TypeScript, etc.)
- [x] I have provided appropriate documentation ([Google-style Python
    docstrings][py-doc-google]) for all packages/modules/functions/classes/
    methods or updated existing ones
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature
    works
- [x] New and existing unit tests pass locally with my changes
- [x] I have not reduced the existing code coverage


#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

[contributing-guidelines]: https://elixir-cloud-aai.github.io/guides/guide-contributor/workflow/
[conv-commits]: https://www.conventionalcommits.org/en
[py-doc-google]: https://google.github.io/styleguide/pyguide.html

## Summary by Sourcery

CI:
- Remove dependency on the 'semantic_pr' job in the 'detect-unresolved-conflicts' job within the 'pr_evaluation' workflow to ensure proper job recognition by GitHub Actions.