### PR TITLE
chore: update `.editorconfig` for `yml` and `Makefile`

### DIFF
--- a/{{ cookiecutter.project_name_dashed }}/.editorconfig
+++ b/{{ cookiecutter.project_name_dashed }}/.editorconfig
@@ -20,3 +20,9 @@ quote_type = double
 
 [*.md]
 max_line_length = 80
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
#### Description

<!-- Please include a summary of the change and the relevant issue(s) it
resolves, if any (otherwise delete that line), e.g., `Fixes #123`. If the PR
addresses more than one issue, please add multiple lines, each starting with
'Fixes #'. Please stick to that syntax precisely, including whitespaces,
otherwise the issue(s) may not be linked to the PR.

In the summary, list any dependencies that are required for this change.
Please use bullet points for the description. Please also briefly describe
the relevant motivation and context briefly. For very trivial changes that are
duly explained by the PR title, a description can be omitted. -->

Yaml files grow horizontally as well, hence its a good idea to make tabwidth to 2. And for Makfile tab are preferred, please refer to [this](https://stackoverflow.com/questions/28712585/when-to-use-space-or-tab-in-makefile).


#### Comments

<!-- If there are unchecked boxes in the list above, but you would still like
your PR to be reviewed or considered for merging, please describe here why
boxes were not checked. For example, if you are positive that your commits
should _not_ be squashed when merging, please explain why you think the PR
warrants or requires multiple commits to be added to the history (but note that
in that case, it is a prerequisite that all commits follow the Conventional
Commits specification). -->

[contributing-guidelines]: https://elixir-cloud-aai.github.io/guides/guide-contributor/workflow/
[conv-commits]: https://www.conventionalcommits.org/en
[py-doc-google]: https://google.github.io/styleguide/pyguide.html

## Summary by Sourcery

Chores:
- Standardize indentation in `.editorconfig` for YAML and Makefile files.