### PR TITLE
fix(ci): make Python version dynamic

### DIFF
--- a/{{ cookiecutter.project_name_dashed }}/.github/actions/setup/poetry/action.yaml
+++ b/{{ cookiecutter.project_name_dashed }}/.github/actions/setup/poetry/action.yaml
@@ -1,4 +1,3 @@
-{% raw %}---
 name: Setup Python and Poetry Action
 description: Configure system, Python, Poetry and deps and cache management.
 
@@ -7,7 +6,7 @@ inputs:
     default: ubuntu-latest
     description: The operating system to use
   python-version:
-    default: '3.11'
+    default: '{{ cookiecutter.python_version }}'
     description: The version of Python to use
   poetry-version:
     default: '1.8.2'
@@ -26,8 +25,8 @@ runs:
     - uses: 'actions/setup-python@v5'
       id: setup-python
       with:
-        python-version: '${{ inputs.python-version }}'
-
+        python-version: '{{ cookiecutter.python_version }}'
+{% raw %}
     - name: Setup pipx environment Variables
       id: pipx-env-setup
       # pipx default home and bin dir are not writable by the cache action
@@ -89,4 +88,4 @@ runs:
       if: steps.poetry-cache.outputs.cache-hit != 'true'
       shell: bash
       run: poetry install ${{ inputs.poetry-install-options }} --no-interaction
-...{% endraw %}
+{% endraw %}

--- a/{{ cookiecutter.project_name_dashed }}/.github/actions/setup/poetry/action.yaml
+++ b/{{ cookiecutter.project_name_dashed }}/.github/actions/setup/poetry/action.yaml
@@ -1,3 +1,4 @@
+---
 name: Setup Python and Poetry Action
 description: Configure system, Python, Poetry and deps and cache management.
 
@@ -89,3 +90,5 @@ runs:
       shell: bash
       run: poetry install ${{ inputs.poetry-install-options }} --no-interaction
 {% endraw %}
+...
+

--- a/{{ cookiecutter.project_name_dashed }}/.github/workflows/vulnerability.yaml
+++ b/{{ cookiecutter.project_name_dashed }}/.github/workflows/vulnerability.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/setup/poetry
         with:
           {% raw %}os: ${{ job.os }}{% endraw %}
-          python-version: '3.11'
+          python-version: '{{ cookiecutter.python_version }}'
           poetry-install-options: "--only=vulnerability --no-root"
           poetry-export-options: "--only=vulnerability"
 
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/actions/setup/poetry
         with:
           {% raw %}os: ${{ job.os }}{% endraw %}
-          python-version: '3.11'
+          python-version: '{{ cookiecutter.python_version }}'
           poetry-install-options: "--only=vulnerability --no-root"
           poetry-export-options: "--only=vulnerability"
 


### PR DESCRIPTION
Resolves: #67

## Summary by Sourcery

CI:
- Use the Python version defined by `cookiecutter.python_version` in the vulnerability check workflow.