### PR TITLE
fix: source `asdf` and initialize `direnv`

### DIFF
--- a/{{ cookiecutter.project_name_dashed }}/.devcontainer/override.zshrc
+++ b/{{ cookiecutter.project_name_dashed }}/.devcontainer/override.zshrc
@@ -13,5 +13,11 @@ plugins=(
 # Load oh-my-zsh with the configured settings
 source $ZSH/oh-my-zsh.sh
 
+# Load asdf
+. "$HOME/.asdf/asdf.sh"
+
+# Initialize direnv
+eval "$(direnv hook zsh)"
+
 # Attempt to activate the Python virtual environment for every session
 source /workspaces/{{ cookiecutter.project_name_dashed }}/.venv/bin/activate 2>/dev/null || true


### PR DESCRIPTION
resolves #65

## Summary by Sourcery

CI:
- Initialize asdf and direnv in the devcontainer's override.zshrc file.